### PR TITLE
Deploy html to github pages and share link

### DIFF
--- a/DEPLOYMENT_INSTRUCTIONS.md
+++ b/DEPLOYMENT_INSTRUCTIONS.md
@@ -1,0 +1,68 @@
+# GitHub Pages Deployment Instructions
+
+## 🎯 Quick Setup
+
+Your HTML file is ready! To deploy it to GitHub Pages, follow these steps:
+
+### 1. Authenticate with GitHub
+```bash
+gh auth login
+```
+Follow the prompts to authenticate with your GitHub account.
+
+### 2. Run the Deployment Script
+```bash
+./deploy-to-github-pages.sh
+```
+
+This script will:
+- Create a public GitHub repository named "temprepo"
+- Push your HTML content to the repository
+- Enable GitHub Pages
+- Provide you with the live URL
+
+### 3. Access Your Site
+
+After running the script, your site will be available at:
+```
+https://[your-github-username].github.io/temprepo
+```
+
+## 📋 What's Included
+
+- `index.html` - A beautiful, responsive webpage with modern styling
+- `deploy-to-github-pages.sh` - Automated deployment script
+- This instruction file
+
+## 🔧 Manual Setup (Alternative)
+
+If you prefer to set up manually:
+
+1. Create a new repository on GitHub named "temprepo"
+2. Add the remote origin:
+   ```bash
+   git remote add origin https://github.com/[username]/temprepo.git
+   ```
+3. Push the code:
+   ```bash
+   git push -u origin main
+   ```
+4. Go to repository Settings → Pages
+5. Select "Deploy from a branch" and choose "main" branch
+6. Save the settings
+
+## 🌐 Expected Result
+
+Your GitHub Pages site will display a modern, responsive webpage with:
+- Welcome message
+- Feature cards highlighting GitHub Pages benefits
+- Professional styling with gradients and hover effects
+- Mobile-responsive design
+
+## ⏱️ Deployment Time
+
+GitHub Pages typically takes 5-10 minutes to build and deploy your site after pushing changes.
+
+---
+
+**Ready to deploy?** Run `./deploy-to-github-pages.sh` to get started!

--- a/deploy-to-github-pages.sh
+++ b/deploy-to-github-pages.sh
@@ -1,0 +1,67 @@
+#!/bin/bash
+
+# GitHub Pages Deployment Script for temprepo
+# This script will create a GitHub repository and enable GitHub Pages
+
+set -e
+
+echo "🚀 GitHub Pages Deployment Script"
+echo "=================================="
+
+# Check if user is authenticated with GitHub CLI
+if ! gh auth status &>/dev/null; then
+    echo "❌ You need to authenticate with GitHub CLI first."
+    echo "Please run: gh auth login"
+    echo "Then run this script again."
+    exit 1
+fi
+
+echo "✅ GitHub CLI authenticated"
+
+# Create the repository
+echo "📦 Creating GitHub repository 'temprepo'..."
+if gh repo create temprepo --public --description "Temporary repository for GitHub Pages" --clone=false; then
+    echo "✅ Repository created successfully"
+else
+    echo "⚠️  Repository might already exist, continuing..."
+fi
+
+# Add remote origin
+echo "🔗 Adding remote origin..."
+git remote remove origin 2>/dev/null || true
+git remote add origin https://github.com/$(gh api user --jq .login)/temprepo.git
+
+# Push to main branch
+echo "📤 Pushing to GitHub..."
+git branch -M main
+git push -u origin main
+
+# Enable GitHub Pages
+echo "🌐 Enabling GitHub Pages..."
+gh api repos/$(gh api user --jq .login)/temprepo/pages \
+    --method POST \
+    --field source[branch]=main \
+    --field source[path]="/" || echo "Pages might already be enabled"
+
+# Wait a moment for GitHub to process
+sleep 5
+
+# Get the GitHub Pages URL
+GITHUB_USERNAME=$(gh api user --jq .login)
+PAGES_URL="https://${GITHUB_USERNAME}.github.io/temprepo"
+
+echo ""
+echo "🎉 Deployment Complete!"
+echo "======================="
+echo "Repository URL: https://github.com/${GITHUB_USERNAME}/temprepo"
+echo "GitHub Pages URL: ${PAGES_URL}"
+echo ""
+echo "📝 Note: It may take a few minutes for your site to be available at the GitHub Pages URL."
+echo "The deployment process can take 5-10 minutes to complete."
+
+# Open the repository in browser (optional)
+read -p "🌐 Would you like to open the repository in your browser? (y/N): " -n 1 -r
+echo
+if [[ $REPLY =~ ^[Yy]$ ]]; then
+    gh repo view --web
+fi

--- a/index.html
+++ b/index.html
@@ -1,0 +1,123 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Temp Repo - GitHub Pages</title>
+    <style>
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+            max-width: 800px;
+            margin: 0 auto;
+            padding: 40px 20px;
+            line-height: 1.6;
+            color: #333;
+            background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+            min-height: 100vh;
+        }
+        
+        .container {
+            background: white;
+            padding: 40px;
+            border-radius: 12px;
+            box-shadow: 0 10px 30px rgba(0,0,0,0.1);
+        }
+        
+        h1 {
+            color: #2c3e50;
+            text-align: center;
+            margin-bottom: 30px;
+            font-size: 2.5em;
+        }
+        
+        .welcome {
+            text-align: center;
+            font-size: 1.2em;
+            color: #666;
+            margin-bottom: 30px;
+        }
+        
+        .features {
+            display: grid;
+            grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+            gap: 20px;
+            margin: 30px 0;
+        }
+        
+        .feature {
+            padding: 20px;
+            border: 2px solid #e1e8ed;
+            border-radius: 8px;
+            text-align: center;
+            transition: transform 0.3s ease;
+        }
+        
+        .feature:hover {
+            transform: translateY(-5px);
+            border-color: #667eea;
+        }
+        
+        .footer {
+            text-align: center;
+            margin-top: 40px;
+            color: #888;
+            font-size: 0.9em;
+        }
+        
+        .btn {
+            display: inline-block;
+            padding: 12px 24px;
+            background: #667eea;
+            color: white;
+            text-decoration: none;
+            border-radius: 6px;
+            transition: background 0.3s ease;
+            margin: 10px;
+        }
+        
+        .btn:hover {
+            background: #5a67d8;
+        }
+    </style>
+</head>
+<body>
+    <div class="container">
+        <h1>🚀 Welcome to Temp Repo</h1>
+        
+        <div class="welcome">
+            This is a temporary repository hosted on GitHub Pages
+        </div>
+        
+        <div class="features">
+            <div class="feature">
+                <h3>📄 Static Site</h3>
+                <p>Simple HTML, CSS, and JavaScript hosting</p>
+            </div>
+            
+            <div class="feature">
+                <h3>🌐 Global CDN</h3>
+                <p>Fast loading from anywhere in the world</p>
+            </div>
+            
+            <div class="feature">
+                <h3>🔒 HTTPS</h3>
+                <p>Secure by default with SSL certificate</p>
+            </div>
+        </div>
+        
+        <div style="text-align: center; margin-top: 30px;">
+            <a href="#" class="btn">Learn More</a>
+            <a href="https://github.com" class="btn">View on GitHub</a>
+        </div>
+        
+        <div class="footer">
+            <p>Generated automatically • Hosted on GitHub Pages</p>
+            <p>Created: <span id="date"></span></p>
+        </div>
+    </div>
+    
+    <script>
+        document.getElementById('date').textContent = new Date().toLocaleDateString();
+    </script>
+</body>
+</html>


### PR DESCRIPTION
Add a sample `index.html` and deployment scripts to set up GitHub Pages for `temprepo`.

The user requested to deploy an HTML file to GitHub Pages. As no specific HTML was provided, a basic `index.html` was created along with a `deploy-to-github-pages.sh` script and `DEPLOYMENT_INSTRUCTIONS.md` to guide the user through the GitHub Pages setup and deployment process.

---
[Slack Thread](https://ohme.slack.com/archives/C098FNDP7KQ/p1758291101626889?thread_ts=1758291101.626889&cid=C098FNDP7KQ)

<a href="https://cursor.com/background-agent?bcId=bc-1729f3c0-a118-4880-8b70-e03b1e21e3ca"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-1729f3c0-a118-4880-8b70-e03b1e21e3ca"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

